### PR TITLE
:sparkle: Adding option to have a overrideLayer in maya usdExport to …

### DIFF
--- a/third_party/maya/lib/usdMaya/exportCommand.cpp
+++ b/third_party/maya/lib/usdMaya/exportCommand.cpp
@@ -117,6 +117,9 @@ MSyntax UsdMayaExportCommand::createSyntax()
     syntax.addFlag("-psc",
                    UsdMayaJobExportArgsTokens->parentScope.GetText(),
                    MSyntax::kString);
+    syntax.addFlag("-ol",
+                   UsdMayaJobExportArgsTokens->overrideLayer.GetText(),
+                   MSyntax::kString);
     syntax.addFlag("-ro",
                    UsdMayaJobExportArgsTokens->renderableOnly.GetText(),
                    MSyntax::kNoArg);

--- a/third_party/maya/lib/usdMaya/instancedNodeWriter.cpp
+++ b/third_party/maya/lib/usdMaya/instancedNodeWriter.cpp
@@ -153,9 +153,7 @@ UsdMaya_InstancedNodeWriter::UsdMaya_InstancedNodeWriter(
 
     _usdPrim.GetReferences().AddReference(
         SdfReference(std::string(), referencePath));
-    //if(!_usdPrim.HasAuthoredInstanceable()) {
-        _usdPrim.SetInstanceable(true);
-    //}
+    _usdPrim.SetInstanceable(true);
 
     // Get the Maya DAG path corresponding to our "instance master" root.
     // We used the 0th instance to write out the USD instance master.

--- a/third_party/maya/lib/usdMaya/instancedNodeWriter.cpp
+++ b/third_party/maya/lib/usdMaya/instancedNodeWriter.cpp
@@ -132,7 +132,7 @@ UsdMaya_InstancedNodeWriter::UsdMaya_InstancedNodeWriter(
         return;
     }
 
-    _usdPrim = GetUsdStage()->DefinePrim(usdInstancePath);
+    _usdPrim = GetUsdStage()->OverridePrim(usdInstancePath);
     if (!TF_VERIFY(
             _usdPrim,
             "Could not define UsdPrim at path '%s'\n",
@@ -153,7 +153,9 @@ UsdMaya_InstancedNodeWriter::UsdMaya_InstancedNodeWriter(
 
     _usdPrim.GetReferences().AddReference(
         SdfReference(std::string(), referencePath));
-    _usdPrim.SetInstanceable(true);
+    //if(!_usdPrim.HasAuthoredInstanceable()) {
+        _usdPrim.SetInstanceable(true);
+    //}
 
     // Get the Maya DAG path corresponding to our "instance master" root.
     // We used the 0th instance to write out the USD instance master.

--- a/third_party/maya/lib/usdMaya/jobArgs.cpp
+++ b/third_party/maya/lib/usdMaya/jobArgs.cpp
@@ -323,6 +323,8 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
                 UsdMayaJobExportArgsTokens->stripNamespaces)),
         parentScope(
             _AbsolutePath(userArgs, UsdMayaJobExportArgsTokens->parentScope)),
+        overrideLayer(
+            _String(userArgs, UsdMayaJobExportArgsTokens->overrideLayer)),
         renderLayerMode(
             _Token(userArgs,
                 UsdMayaJobExportArgsTokens->renderLayerMode,
@@ -385,6 +387,7 @@ operator <<(std::ostream& out, const UsdMayaJobExportArgs& exportArgs)
         << "mergeTransformAndShape: " << TfStringify(exportArgs.mergeTransformAndShape) << std::endl
         << "normalizeNurbs: " << TfStringify(exportArgs.normalizeNurbs) << std::endl
         << "parentScope: " << exportArgs.parentScope << std::endl
+        << "overrideLayer: " << exportArgs.overrideLayer << std::endl
         << "renderLayerMode: " << exportArgs.renderLayerMode << std::endl
         << "rootKind: " << exportArgs.rootKind << std::endl
         << "shadingMode: " << exportArgs.shadingMode << std::endl
@@ -477,6 +480,7 @@ UsdMayaJobExportArgs::GetDefaultDictionary()
         d[UsdMayaJobExportArgsTokens->mergeTransformAndShape] = true;
         d[UsdMayaJobExportArgsTokens->normalizeNurbs] = false;
         d[UsdMayaJobExportArgsTokens->parentScope] = std::string();
+        d[UsdMayaJobExportArgsTokens->overrideLayer] = std::string();
         d[UsdMayaJobExportArgsTokens->pythonPerFrameCallback] = std::string();
         d[UsdMayaJobExportArgsTokens->pythonPostCallback] = std::string();
         d[UsdMayaJobExportArgsTokens->renderableOnly] = false;

--- a/third_party/maya/lib/usdMaya/jobArgs.h
+++ b/third_party/maya/lib/usdMaya/jobArgs.h
@@ -88,6 +88,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (mergeTransformAndShape) \
     (normalizeNurbs) \
     (parentScope) \
+    (overrideLayer) \
     (pythonPerFrameCallback) \
     (pythonPostCallback) \
     (renderableOnly) \
@@ -180,6 +181,7 @@ struct UsdMayaJobExportArgs
     const TfToken rootKind;
     const TfToken shadingMode;
     const bool verbose;
+    const std::string overrideLayer;
 
     typedef std::map<std::string, std::string> ChaserArgs;
     const std::vector<std::string> chaserNames;

--- a/third_party/maya/lib/usdMaya/shadingModeDisplayColor.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeDisplayColor.cpp
@@ -184,18 +184,14 @@ private:
             // emphasizing that the interface is a value provider for
             // its shading networks.
 
-            //UsdShadeInput dispColorIA = material.GetInput(_tokens->displayColor);
-            //if(!dispColorIA) {
+
             UsdShadeInput dispColorIA = material.CreateInput(_tokens->displayColor,
                                      SdfValueTypeNames->Color3f);
-            //    dispColorIA.Set(VtValue(color));
-            //} else {
-                VtValue currentVal;
-                dispColorIA.Get(&currentVal);
-                if( currentVal != VtValue(color)) {
-                    dispColorIA.Set(VtValue(color));
-                }
-            //}
+            VtValue currentVal;
+            dispColorIA.Get(&currentVal);
+            if( currentVal != VtValue(color)) {
+                dispColorIA.Set(VtValue(color));
+            }
 
             const std::string shaderName =
                 TfStringPrintf("%s_lambert", materialPrim.GetName().GetText());

--- a/third_party/maya/lib/usdMaya/shadingModeExporterContext.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeExporterContext.cpp
@@ -461,10 +461,14 @@ UsdMayaShadingModeExportContext::MakeStandardMaterialPrim(
             assignmentsToBind)) {
         SdfPath materialPath = materialParent.GetPath().AppendChild(
                 TfToken(materialName));
-        UsdShadeMaterial material = UsdShadeMaterial::Define(
-                GetUsdStage(), materialPath);
-
-        UsdPrim materialPrim = material.GetPrim();
+        UsdPrim materialPrim = GetUsdStage()->GetPrimAtPath(materialPath);
+        UsdShadeMaterial material  = UsdShadeMaterial::Get(
+                    GetUsdStage(), materialPath);
+        if (!materialPrim) {
+            material = UsdShadeMaterial::Define(
+                    GetUsdStage(), materialPath);
+            materialPrim = material.GetPrim();
+        }
 
         // could use this to determine where we want to export.
         TF_FOR_ALL(iter, assignmentsToBind) {
@@ -491,7 +495,14 @@ UsdMayaShadingModeExportContext::MakeStandardMaterialPrim(
                     }
                     else {
                         UsdPrim boundPrim = stage->OverridePrim(boundPrimPath);
-                        UsdShadeMaterialBindingAPI(boundPrim).Bind(material);
+                        UsdShadeMaterialBindingAPI bindingAPI;
+                        bindingAPI = UsdShadeMaterialBindingAPI(boundPrim);
+                        UsdPrim foundMaterialPrim =
+                            bindingAPI.ComputeBoundMaterial().GetPrim();
+                        if (foundMaterialPrim != materialPrim) {
+                            // only do binding if we have changed the material prim
+                            bindingAPI.Bind(material);
+                        }
                     }
                 }
 

--- a/third_party/maya/lib/usdMaya/translatorGprim.cpp
+++ b/third_party/maya/lib/usdMaya/translatorGprim.cpp
@@ -60,8 +60,18 @@ UsdMayaTranslatorGprim::Write(
 
     bool doubleSided = false;
     if (UsdMayaUtil::getPlugValue(depFn, "doubleSided", &doubleSided)){
-        if(!gprim.GetDoubleSidedAttr().HasAuthoredValue()){
-            gprim.CreateDoubleSidedAttr(VtValue(doubleSided), true);
+        UsdAttribute doubleSideAttr = gprim.GetDoubleSidedAttr();
+        VtValue val = VtValue(doubleSided);
+        bool createAttr = true;
+        if(doubleSideAttr) {
+            bool primDoubleSided;
+            doubleSideAttr.Get(&primDoubleSided);
+            if(primDoubleSided == doubleSided && doubleSideAttr.HasAuthoredValue()) {
+                createAttr = false;
+            }
+        }
+        if(createAttr) {
+            gprim.CreateDoubleSidedAttr(val, true);
         }
     }
 
@@ -71,7 +81,17 @@ UsdMayaTranslatorGprim::Write(
         // If mesh is double sided in maya, opposite is disregarded
         TfToken orientation = (opposite && !doubleSided ? UsdGeomTokens->leftHanded :
                                                           UsdGeomTokens->rightHanded);
-        if(!gprim.GetOrientationAttr().HasAuthoredValue()){
+        UsdAttribute orientationAttr = gprim.GetOrientationAttr();
+        TfToken primOrientation;
+        bool createAttr = true;
+        if(orientationAttr) {
+            TfToken primOrientation;
+            orientationAttr.Get(&primOrientation);
+            if(primOrientation == orientation && orientationAttr.HasAuthoredValue()) {
+                createAttr = false;
+            }
+        }
+        if(createAttr) {
             gprim.CreateOrientationAttr(VtValue(orientation), true);
         }
     }

--- a/third_party/maya/lib/usdMaya/translatorGprim.cpp
+++ b/third_party/maya/lib/usdMaya/translatorGprim.cpp
@@ -60,7 +60,9 @@ UsdMayaTranslatorGprim::Write(
 
     bool doubleSided = false;
     if (UsdMayaUtil::getPlugValue(depFn, "doubleSided", &doubleSided)){
-        gprim.CreateDoubleSidedAttr(VtValue(doubleSided), true);
+        if(!gprim.GetDoubleSidedAttr().HasAuthoredValue()){
+            gprim.CreateDoubleSidedAttr(VtValue(doubleSided), true);
+        }
     }
 
     bool opposite = false;
@@ -69,7 +71,9 @@ UsdMayaTranslatorGprim::Write(
         // If mesh is double sided in maya, opposite is disregarded
         TfToken orientation = (opposite && !doubleSided ? UsdGeomTokens->leftHanded :
                                                           UsdGeomTokens->rightHanded);
-        gprim.CreateOrientationAttr(VtValue(orientation), true);
+        if(!gprim.GetOrientationAttr().HasAuthoredValue()){
+            gprim.CreateOrientationAttr(VtValue(orientation), true);
+        }
     }
 
 }

--- a/third_party/maya/lib/usdMaya/writeJob.cpp
+++ b/third_party/maya/lib/usdMaya/writeJob.cpp
@@ -416,7 +416,7 @@ UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     // Perform post-processing for instances, skel, etc.
     // We shouldn't be creating new instance masters after this point, and we
     // want to cleanup the InstanceSources prim before writing model hierarchy.
-    if (!mJobCtx._PostProcess()) {
+    if (!mJobCtx._PostProcess(mDagPathToUsdPathMap)) {
         return false;
     }
 

--- a/third_party/maya/lib/usdMaya/writeJobContext.cpp
+++ b/third_party/maya/lib/usdMaya/writeJobContext.cpp
@@ -426,6 +426,11 @@ UsdMayaWriteJobContext::_OpenFile(const std::string& filename, bool append)
         return false;
     }
 
+   if (mArgs.overrideLayer != "") {
+        std::vector<std::string> sublayers(1,mArgs.overrideLayer);
+        layer->SetSubLayerPaths(sublayers);
+   }
+
     if (!mArgs.parentScope.IsEmpty()) {
         mParentScopePath = mArgs.parentScope;
         // Note that we only need to create the parentScope prim if we're not
@@ -481,6 +486,12 @@ UsdMayaWriteJobContext::_PostProcess()
                         instancesPrimPath.GetText());
             }
         }
+    }
+
+    if (mArgs.overrideLayer != "") {
+        // Remove override sublayers.
+        std::vector<std::string> sublayers;
+        mStage->GetRootLayer()->SetSubLayerPaths(sublayers);
     }
 
     if (!_skelBindingsProcessor->PostProcessSkelBindings(mStage)) {

--- a/third_party/maya/lib/usdMaya/writeJobContext.h
+++ b/third_party/maya/lib/usdMaya/writeJobContext.h
@@ -155,7 +155,7 @@ protected:
 
     /// Perform any necessary cleanup; call this before you save the stage.
     PXRUSDMAYA_API
-    bool _PostProcess();
+    bool _PostProcess(const UsdMayaUtil::MDagPathMap<SdfPath> &DagPathToUsdPathMap);
 
     UsdMayaJobExportArgs mArgs;
     // List of the primitive writers to iterate over

--- a/third_party/maya/lib/usdMaya/writeUtil.cpp
+++ b/third_party/maya/lib/usdMaya/writeUtil.cpp
@@ -1014,7 +1014,11 @@ UsdMayaWriteUtil::WriteMetadataToPrim(
     }
 
     for (const auto& keyValue : adaptor.GetAllAuthoredMetadata()) {
-        prim.SetMetadata(keyValue.first, keyValue.second);
+        VtValue value;
+        prim.GetMetadata(keyValue.first, &value);
+        if (value != keyValue.second) {
+            prim.SetMetadata(keyValue.first, keyValue.second);
+        }
     }
     return true;
 }

--- a/third_party/maya/plugin/pxrUsdTranslators/meshWriter.cpp
+++ b/third_party/maya/plugin/pxrUsdTranslators/meshWriter.cpp
@@ -256,7 +256,8 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     UsdGeomPointBased::ComputeExtent(points, &extent);
 
     _SetAttribute(primSchema.GetPointsAttr(), &points, usdTime);
-    _SetAttribute(primSchema.CreateExtentAttr(), &extent, usdTime);
+    _SetAttribute(primSchema.CreateExtentAttr(VtValue(),true),
+                  &extent, usdTime);
 
     // Get faceVertexIndices
     unsigned int numFaceVertices = geomMesh.numFaceVertices(&status);


### PR DESCRIPTION
# Description of Change(s)

- Added argument for usdExport to be able to export overrides from a specified overrideLayer
- Updated code to make it possible to create overrides on export where previously it always wrote out to the layer regardless of if the prim and attributes existed.

