### PR TITLE
🐛 cmake bugfix, remove too many parenthesis

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -376,7 +376,7 @@ def RunCMake(context, force, extraArgs = None):
             '{toolset} '
             '{extraArgs} '
             '"{srcDir}"'
-            .format(cmake=os.environ.get("CMAKE","cmake3")),
+            .format(cmake=os.environ.get("CMAKE","cmake3"),
                     instDir=instDir,
                     depsInstDir=context.instDir,
                     config=config,


### PR DESCRIPTION
### Description of Change(s)
Fix too many parenthesis
### Fixes Issue(s)
- Fix too many parenthesis

